### PR TITLE
Fix security issue with images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,7 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
+  images: {
+    domains: ["images.ctfassets.net"],
+  },
 };


### PR DESCRIPTION
# Why?

There's an issue with the images when deploying the app to Netlify. See the screenshot:

![image](https://user-images.githubusercontent.com/76222554/147281426-d56a1081-ce96-4d58-b9e6-cf90c71443e3.png)

# How?


- Add a config option for Netlify to enable loading resources from third-party domain: Contentful CDN.

# UI changes?

> No UI Changes.